### PR TITLE
fix: Correct timestamp conversion for timezone-aware datetimes

### DIFF
--- a/init-typesense.py
+++ b/init-typesense.py
@@ -168,8 +168,9 @@ def download_and_process_dataset():
         df['published_month'] = df['published_at'].dt.month
 
         # Convert datetime to Unix timestamp (seconds) for Typesense
-        df['published_at_ts'] = df['published_at'].astype('int64') // 10**9
-        df['extracted_at_ts'] = df['extracted_at'].astype('int64') // 10**9
+        # Use .timestamp() to handle timezone-aware datetimes and any precision (ns, us, ms)
+        df['published_at_ts'] = df['published_at'].apply(lambda x: int(x.timestamp()) if pd.notna(x) else 0)
+        df['extracted_at_ts'] = df['extracted_at'].apply(lambda x: int(x.timestamp()) if pd.notna(x) else 0)
 
         # Calculate ISO 8601 week (YYYYWW format) for temporal analysis
         logger.info("Calculating ISO 8601 weeks for temporal optimization...")


### PR DESCRIPTION
## 🐛 Bug Fix - Critical

Fix critical bug where all articles in the Portal displayed epoch timestamp (January 21, 1970) instead of actual publication dates.

## Root Cause

After the `published_at` migration from date to datetime, the HuggingFace dataset stores timestamps with **microsecond precision** (`datetime64[us, pytz.FixedOffset(-180)]`).

However, the code still divided by `10**9` (expecting nanoseconds), resulting in timestamps that were **1000x too small**.

**Example:**
- Correct: `1731878640` seconds (Nov 18, 2025)
- Buggy: `1731878` seconds (Jan 21, 1970)

## Solution

Changed from:
```python
df['published_at_ts'] = df['published_at'].astype('int64') // 10**9
```

To:
```python
df['published_at_ts'] = df['published_at'].apply(lambda x: int(x.timestamp()) if pd.notna(x) else 0)
```

The `.timestamp()` method:
✅ Handles any datetime precision (ns, us, ms) automatically
✅ Correctly processes timezone-aware datetimes  
✅ Returns Unix timestamp in seconds
✅ Handles NaT values gracefully

## Testing

**Before:** Portal shows "21 de jan. de 1970 às 06h52" for all articles
**After:** Correct dates like "19 de nov de 2025 às 16h18"

Test locally:
```bash
./run-typesense-server.sh cleanup
./run-typesense-server.sh
# Check Portal at localhost
```

## Related

- Scraper PR: nitaibezerra/govbrnews-scraper#49
- Typesense Docker PR: #2 (superseded by this fix)
- Typesense Infra: Similar fix needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)