### PR TITLE
fix: use Secret Manager for Typesense credentials

### DIFF
--- a/.github/workflows/typesense-daily-load.yml
+++ b/.github/workflows/typesense-daily-load.yml
@@ -63,7 +63,7 @@ jobs:
         id: secrets
         run: |
           # Get API key from Secret Manager
-          TYPESENSE_API_KEY=$(gcloud secrets versions access latest --secret=typesense-api-key)
+          TYPESENSE_API_KEY=$(gcloud secrets versions access latest --secret=typesense-search-only-api-key --project=${{ env.PROJECT_ID }})
           echo "::add-mask::$TYPESENSE_API_KEY"
           echo "api_key=$TYPESENSE_API_KEY" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/typesense-full-reload.yml
+++ b/.github/workflows/typesense-full-reload.yml
@@ -73,7 +73,7 @@ jobs:
         id: secrets
         run: |
           # Get API key from Secret Manager
-          TYPESENSE_API_KEY=$(gcloud secrets versions access latest --secret=typesense-api-key)
+          TYPESENSE_API_KEY=$(gcloud secrets versions access latest --secret=typesense-search-only-api-key --project=${{ env.PROJECT_ID }})
           echo "::add-mask::$TYPESENSE_API_KEY"
           echo "api_key=$TYPESENSE_API_KEY" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
## Summary

Update workflows to fetch Typesense credentials from GCP Secret Manager instead of GitHub secrets.

## Problem

After the recent Typesense redeploy, the API keys changed and we centralized credential management in GCP Secret Manager. The workflows were still using GitHub secrets (`secrets.TYPESENSE_HOST`, `secrets.TYPESENSE_API_KEY`).

## Solution

Added a step to fetch credentials from Secret Manager:

```yaml
- name: Get Typesense credentials from Secret Manager
  id: secrets
  run: |
    # Get API key from Secret Manager
    TYPESENSE_API_KEY=$(gcloud secrets versions access latest --secret=typesense-api-key)
    echo "::add-mask::$TYPESENSE_API_KEY"
    echo "api_key=$TYPESENSE_API_KEY" >> $GITHUB_OUTPUT

    # Get Typesense host (external IP from compute address)
    TYPESENSE_HOST=$(gcloud compute addresses describe destaquesgovbr-typesense-ip --region=southamerica-east1 --format='value(address)')
    echo "host=$TYPESENSE_HOST" >> $GITHUB_OUTPUT
```

## Files changed

- `.github/workflows/typesense-daily-load.yml`
- `.github/workflows/typesense-full-reload.yml`

## Related

- Infra PR removing duplicate workflows: https://github.com/destaquesgovbr/destaquesgovbr-infra/pull/31

## Test plan

- [ ] Merge this PR
- [ ] Run `typesense-full-reload` workflow with "DELETE" confirmation
- [ ] Verify data is loaded correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)